### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Integration/LogParserTest.php
+++ b/tests/Integration/LogParserTest.php
@@ -8,12 +8,13 @@
 
 namespace Piwik\Plugins\VisitorGenerator\tests\Integration;
 use Piwik\Plugins\VisitorGenerator\LogParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group VisitorGenerator
  * @group LogParserTest
  */
-class LogParserTest extends \PHPUnit_Framework_TestCase
+class LogParserTest extends TestCase
 {
     /**
      * @var LogParser


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

refs piwik/piwik#12269