### PR TITLE
Couple tweaks to generate-live-visits command

### DIFF
--- a/Commands/GenerateLiveVisits.php
+++ b/Commands/GenerateLiveVisits.php
@@ -32,7 +32,7 @@ class GenerateLiveVisits extends ConsoleCommand
             Date::now()->toString('j'));
         $this->addOption('time-of-day', null, InputOption::VALUE_REQUIRED,
             'The time of day to start replaying logs for. Defaults to now, specify a value here to override.',
-            time());
+            time() % LiveVisitsFromLog::SECONDS_IN_DAY);
         $this->addOption('custom-matomo-url', null, InputOption::VALUE_REQUIRED, 'Custom Matomo URL to track to.');
     }
 
@@ -68,6 +68,7 @@ class GenerateLiveVisits extends ConsoleCommand
                 return 0;
             }
 
+            $output->writeln("  sleeping {$nextWaitTime}s.");
             sleep($nextWaitTime);
 
             if ($stopAfter > 0

--- a/Generator/LiveVisitsFromLog.php
+++ b/Generator/LiveVisitsFromLog.php
@@ -82,7 +82,7 @@ class LiveVisitsFromLog extends VisitsFromLogs
     public function tick()
     {
         if (!$this->logIterator->valid()) {
-            throw new \Exception("Illegal state: no logs to track (maybe there are no lines for the day of month).");
+            throw new \Exception("Illegal state: no logs to track (maybe there are no lines for the day of month or time of day).");
         }
 
         $currentDate = date('Y-m-d');


### PR DESCRIPTION
Changes:
* fix to default value for --time-of-day option
* add log for how long sleep time is
* tweak to exception message if no logs to track