### PR TITLE
In generate-live-visits, pick first log that is within delta of current time...

### DIFF
--- a/Commands/GenerateLiveVisits.php
+++ b/Commands/GenerateLiveVisits.php
@@ -45,7 +45,9 @@ class GenerateLiveVisits extends ConsoleCommand
         $dayOfMonth = $this->getPostiveIntegerOption($input, 'day-of-month');
         $timeOfDay = $this->getPostiveIntegerOption($input, 'time-of-day');
 
-        $generateLiveVisits = new LiveVisitsFromLog($logFile, $idSite, $timeOfDay, $dayOfMonth, $piwikUrl);
+        $timeOfDayDelta = $stopAfter ?: LiveVisitsFromLog::SECONDS_IN_DAY;
+
+        $generateLiveVisits = new LiveVisitsFromLog($logFile, $idSite, $timeOfDay, $timeOfDayDelta, $dayOfMonth, $piwikUrl);
 
         $output->writeln("Generating logs...");
 

--- a/Generator/LiveVisitsFromLog.php
+++ b/Generator/LiveVisitsFromLog.php
@@ -38,6 +38,11 @@ class LiveVisitsFromLog extends VisitsFromLogs
     private $timeOfDay;
 
     /**
+     * @var int
+     */
+    private $timeOfDayDelta;
+
+    /**
      * @var int|null
      */
     private $dayOfMonth;
@@ -62,12 +67,13 @@ class LiveVisitsFromLog extends VisitsFromLogs
      */
     private $languageIndex = 0;
 
-    public function __construct($logFile, $idSite, $timeOfDay, $dayOfMonth = null, $piwikUrl = null)
+    public function __construct($logFile, $idSite, $timeOfDay, $timeOfDayDelta, $dayOfMonth = null, $piwikUrl = null)
     {
         parent::__construct($piwikUrl);
 
         $this->idSite = $idSite;
         $this->timeOfDay = $timeOfDay;
+        $this->timeOfDayDelta = $timeOfDayDelta;
         $this->dayOfMonth = $dayOfMonth;
         $this->logger = StaticContainer::get(LoggerInterface::class);
         $this->languages = Request::getAcceptLanguages();
@@ -229,7 +235,7 @@ class LiveVisitsFromLog extends VisitsFromLogs
 
             $logTimeOfDay = Date::factory($log['time'])->getTimestamp() % self::SECONDS_IN_DAY;
             $distance = $logTimeOfDay - $this->timeOfDay;
-            if ($distance >= 0 && $distance <= 60) {
+            if ($distance >= 0 && $distance <= $this->timeOfDayDelta) {
                 return;
             }
 

--- a/Generator/LiveVisitsFromLog.php
+++ b/Generator/LiveVisitsFromLog.php
@@ -228,7 +228,8 @@ class LiveVisitsFromLog extends VisitsFromLogs
             $log = $this->logIterator->current();
 
             $logTimeOfDay = Date::factory($log['time'])->getTimestamp() % self::SECONDS_IN_DAY;
-            if ($logTimeOfDay >= $this->timeOfDay) {
+            $distance = $logTimeOfDay - $this->timeOfDay;
+            if ($distance >= 0 && $distance <= 60) {
                 return;
             }
 


### PR DESCRIPTION
... instead of first log that is after current time.

Only finding the first log that is after the current time can lead to a situation where each execution of the command uses the same exact logs, causing extra long visits w/ the same exact actions.