### PR TITLE
Two changes to live visits replay

### DIFF
--- a/Commands/GenerateLiveVisits.php
+++ b/Commands/GenerateLiveVisits.php
@@ -52,6 +52,11 @@ class GenerateLiveVisits extends ConsoleCommand
         $startTime = time();
         while (true) {
             list($count, $nextWaitTime) = $generateLiveVisits->tick();
+            if ($count === null) {
+                $output->writeln("Found no logs to track for day of month / time of day, exiting.");
+                return 0;
+            }
+
             $output->writeln("  tracked $count actions.");
 
             if ($nextWaitTime === null) {

--- a/Generator/LiveVisitsFromLog.php
+++ b/Generator/LiveVisitsFromLog.php
@@ -82,7 +82,7 @@ class LiveVisitsFromLog extends VisitsFromLogs
     public function tick()
     {
         if (!$this->logIterator->valid()) {
-            throw new \Exception("Illegal state: no logs to track (maybe there are no lines for the day of month or time of day).");
+            return [null, null];
         }
 
         $currentDate = date('Y-m-d');

--- a/Iterator/FileLineIterator.php
+++ b/Iterator/FileLineIterator.php
@@ -29,7 +29,7 @@ class FileLineIterator implements \SeekableIterator
     {
         $this->file = new \SplFileObject($file);
         $this->lineNumber = 0;
-        $this->currentLine = $this->file->fgets();
+        $this->fetchCurrentLine();
     }
 
     public function current()
@@ -40,12 +40,7 @@ class FileLineIterator implements \SeekableIterator
     public function next()
     {
         ++$this->lineNumber;
-
-        if (!$this->file->eof()) {
-            $this->currentLine = $this->file->fgets();
-        } else {
-            $this->currentLine = false;
-        }
+        $this->fetchCurrentLine();
     }
 
     public function key()
@@ -61,15 +56,28 @@ class FileLineIterator implements \SeekableIterator
     public function rewind()
     {
         $this->file->fseek(0);
+        $this->lineNumber = 0;
+        $this->fetchCurrentLine();
     }
 
     public function seek($position)
     {
         $this->file->seek($position);
+        $this->lineNumber = $position;
+        $this->fetchCurrentLine();
     }
 
     public function close()
     {
         $this->file = null;
+    }
+
+    private function fetchCurrentLine()
+    {
+        if (!$this->file->eof()) {
+            $this->currentLine = $this->file->fgets();
+        } else {
+            $this->currentLine = false;
+        }
     }
 }


### PR DESCRIPTION
Changes:
1. Do not throw if there are no logs to generate for current day/time.
2. Manage state correctly in FileLineIterator when seeking/rewinding.