### PR TITLE
Correct URL processing in manipulateRequestUrl after LogHelper regex change.

### DIFF
--- a/Generator/VisitsFromLogs.php
+++ b/Generator/VisitsFromLogs.php
@@ -78,7 +78,7 @@ class VisitsFromLogs extends Generator
     protected function manipulateRequestUrl($time, $idSite, $url, $date, $ip, $prefix)
     {
         $start = strpos($url, 'piwik.php?') + strlen('piwik.php?');
-        $url   = substr($url, $start, strrpos($url, " ") - $start);
+        $url   = substr($url, $start);
         $ip    = strlen($ip) < 9 ? "13.5.111.3" : $ip;
         $datetime = $date . " " . Date::factory($time)->toString("H:i:s");
 


### PR DESCRIPTION
I changed the regex a while back so it wouldn't capture the HTTP version from the log in the URL, but this code was still expecting it to be there.