### PR TITLE
Allow PHPCS to be run manually on 6.x-dev [ignore_release]

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,6 +1,8 @@
 name: PHPCS check
 
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   actions: read


### PR DESCRIPTION
## Description

On `5.x-dev` the PHPCS check can be started by hand; on `6.x-dev` it runs on pull requests only. The two branches drifted when the push triggers were dropped from 5.x — that change kept `workflow_dispatch`, and 6.x-dev never picked it up. This restores it, leaving the trigger block identical on both branches.

No version bump or changelog entry: this is CI-only and changes nothing that ships.

## Issue No

NA — found while auditing 5.x/6.x CI drift ahead of the Matomo 6 release.

## Steps to Replicate the Issue

1. Open the Actions tab on `6.x-dev` and select the PHPCS check.
2. Expected: a "Run workflow" button, as on `5.x-dev`.
3. Actual: no button — the workflow only accepts `pull_request`.

## Checklist
- [NA] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
